### PR TITLE
Fix wrong model path

### DIFF
--- a/Resources/GameData/PayloadRetentionSystemNext/Parts/TrunnionPort/TrunnionPort.cfg
+++ b/Resources/GameData/PayloadRetentionSystemNext/Parts/TrunnionPort/TrunnionPort.cfg
@@ -45,7 +45,7 @@
 	
 	MODEL
 	{
-		model = TrunnionPort/Parts/TrunnionPort/TrunnionPort
+		model = PayloadRetentionSystemNext/Parts/TrunnionPort/TrunnionPort
 	}
 
 	MODULE


### PR DESCRIPTION
This pull is based off of forum comment by https://forum.kerbalspaceprogram.com/topic/219575-payload-retention-system-next/?do=findComment&comment=4324978, who noticed that this model path might be wrong.

Also, is https://github.com/meirumeiru/PayloadRetentionSystem-Next/tree/main/Resources/GameData/PayloadRetentionSystemNext/Parts/TrunnionPins missing a .cfg file? Or am I misinterpreting what that folder is for?